### PR TITLE
Ed replace sign up

### DIFF
--- a/content/documentation/for-developers.md
+++ b/content/documentation/for-developers.md
@@ -5,34 +5,23 @@ type: essay
 abstract: "API docs and Quire repository guide"
 ---
 
+Quire is in a limited beta and not yet released as open source software. For a free license to use Quire for your publication projects, and for additional access to support, [please sign up](https://docs.google.com/forms/d/e/1FAIpQLScKOJEq9ivhwizmdazjuhxBII-s-5SUsnerWmyF8VteeeRBhA/viewform)
+
+Quire is centered around the static-site generator [Hugo](https://github.com/gohugoio/hugo). It is written in JavaScript and requires [Node.js LTS](https://nodejs.org/en/) to run.
+
 ## Repositories
 
-There are four repositories hosted on GitHub that make up Quire, which is currently in closed beta. Please [sign-up for access](https://forms.gle/m1fgZu5BHKhddMrW7).
+### quire
 
-### `quire-cli`
+https://github.com/thegetty/quire
 
-https://github.com/gettypubs/quire-cli
+This repo contains the command-line interface for Quire (packages/cli), default starter content (starters/default) used as placeholder content when starting a new Quire project, and a default theme (themes/default) designed to broadly cover a full range of use-cases and to demonstrate the range of the Quire content model. 
 
-The command-line interface for Quire. It can be installed on macOS, Windows or Linux. It is written in JavaScript and requires [Node.js 12.18.3 LTS](https://nodejs.org) to run. Commands include `quire preview`, `quire pdf`, `quire epub`, and more. A complete reference can be found in [Quire CLI Commands](/documentation/quire-cli/).
+### quire-docs
 
-### `quire-starter-theme`
+https://github.com/thegetty/quire-docs
 
-https://github.com/gettypubs/quire-starter-theme
-
-The theme that is included when starting a new Quire project with the `quire new` command. It is designed to broadly cover a full range of use-cases and to demonstrate the range of Quire content model. The theme is where all the page templates and layout logic exist. Quire is built on [Hugo](https://gohugo.io/).
-
-### `quire-starter`
-
-https://github.com/gettypubs/quire-starter
-
-A starter content repository used as placeholder content when starting a new Quire project with the `quire new` command. It comes with some pre-defined example content and pages with which to get started.
-
-### `quire`
-
-https://github.com/gettypubs/quire
-
-The Quire website, and the central location for issues and discussion forum posts.
-
+This repo is specifically for the Quire website and documentation.
 
 ## Configuration
 

--- a/content/documentation/implementation.md
+++ b/content/documentation/implementation.md
@@ -37,12 +37,14 @@ Quire is free to use, however, there are occasionally associated costs:
 
 - Using Quire for journal publishing is also an option, though not yet fully developed.
 
-## Beta Status & Licensing
+## Licensing
 
-- Quire is in a closed testing phase. We are happy to grant [access upon request](https://forms.gle/m1fgZu5BHKhddMrW7).
+- A Quire license enables users to create publications with Quire and distribute as they see fit. Users can modify the default theme in any way that suits their needs. However, we ask that users **don’t redistribute Quire itself.**
 
-- Quire is beta software. While fully functioning, changes and improvements are continuing to be made to it which may lead to incompatibility across versions.
+- For a free license to use Quire for your publication projects, and for additional access to support, [please sign up](https://docs.google.com/forms/d/e/1FAIpQLScKOJEq9ivhwizmdazjuhxBII-s-5SUsnerWmyF8VteeeRBhA/viewform).
+
+## Versioning
+
+- Quire is in limited beta. While fully functioning, changes and improvements are continuing to be made to it which may lead to incompatibility across versions.
 
 - Quire projects, once published, no longer require Quire to keep running. After publication, a compatible version of Quire would only be necessary to make new updates and re-output the various file formats. Older versions can be downloaded on GitHub: https://github.com/gettypubs/quire/releases
-
-- Beta access enables users to create publications with Quire and distribute as they see fit. Users can modify the default theme in any way that suits their needs. However, we ask that users **don’t redistribute Quire itself.**

--- a/content/tutorial.md
+++ b/content/tutorial.md
@@ -228,6 +228,6 @@ For the online edition, type `quire site` and press enter. A `site` directory wi
 Congratulations on completing the tutorial! We’ve touched on Quire’s core concepts and functionality, but of course there’s more to learn and do.
 
 - [Watch a 90-minute webinar recording](https://youtu.be/kFTcJLbMDxs) that walks through many of the steps in this tutorial.
-- [Sign up for beta access](https://goo.gl/forms/IaQ8kHH6Y2YyVlgr1), if you haven’t already, to work with Quire on your own.
-- Continue reading the docs.
+- [Sign up to use Quire](ttps://docs.google.com/forms/d/e/1FAIpQLScKOJEq9ivhwizmdazjuhxBII-s-5SUsnerWmyF8VteeeRBhA/viewform) for a free license and additional access to support.
+- Continue reading the documentation.
 - Start working on your own Quire project.


### PR DESCRIPTION
Remove mentions of "beta"
Replace sign-up link with the correct link 

Questions: 
- I updated the repository information in For Developers section. Does this work?
- In Implementation Considerations, there is a mention of past versions. What is the correct link? Should I also expand on licensing information in this section or is what we have sufficient?