### PR TITLE
Docs/add to glossary

### DIFF
--- a/content/documentation/citation-bibliographies.md
+++ b/content/documentation/citation-bibliographies.md
@@ -5,7 +5,7 @@ type: essay
 abstract: "Cite sources with pop-ups and generate reference lists"
 ---
 
-In-text citations and bibliographies are all available in Quire. Designed to meet scholarly needs and multiple citation styles, they are easy to implement in your publications. While bibliographic references are formatted in YAML and stored in a YAML file (you can consult our [YAML syntax fundamentals](/documentation/fundamentals/) for more information), citation and bibliography shortcodes are used to integrate the references in your publication.
+In-text citations and bibliographies are all available in Quire. Designed to meet scholarly needs and multiple citation styles, they are easy to implement in your publications. While bibliographic references are formatted in YAML and stored in a YAML file (you can consult our [YAML syntax fundamentals](/documentation/fundamentals/) for more information), citation and bibliography {{< q-def "shortcodes" >}} are used to integrate the references in your publication.
 
 ## Capture Bibliographic Information in YAML
 

--- a/content/documentation/contributors.md
+++ b/content/documentation/contributors.md
@@ -5,7 +5,7 @@ type: essay
 abstract: "Credit and include multiple contributors"
 ---
 
-Quire is designed to credit and add contributors to publications in a flexible way. Contributors' data is stored in the `publication.yml` file of your project or in the YAML block of individual pages. The `q-contributor` shortcode offers multiple options to display contributors' data in your publication.
+Quire is designed to credit and add contributors to publications in a flexible way. Contributors' data is stored in the `publication.yml` file of your project or in the YAML block of individual pages. The `q-contributor` shortcode offers multiple options to display contributors' data in your publication. As a reminder, a shortcode is a simple snippet of code inserted in a Markdown file that pulls in information from other files in your project.
 
 ## Add Contributors to Your Project
 

--- a/content/documentation/figure-images.md
+++ b/content/documentation/figure-images.md
@@ -5,7 +5,7 @@ type: essay
 abstract: "Incorporate multiple images, videos, and other multimedia"
 ---
 
-Quire books are visual and the framework is built to support the use of images for scholarly purposes. On this page, we explain where images are placed in the project and how you can manage them. We recommend using the `figures.yml` file to manage all the information about your images, and then inserting them into your Markdown documents where they are needed with the [`q-figure` shortcode](#inserting-figure-images-with-the-q-figure-shortcode).
+Quire books are visual and the framework is built to support the use of images for scholarly purposes. On this page, we explain where images are placed in the project and how you can manage them. We recommend using the `figures.yml` file to manage all the information about your images, and then inserting them into your Markdown documents where they are needed with the [`q-figure` shortcode](#inserting-figure-images-with-the-q-figure-shortcode). As a reminder, a shortcode is a simple snippet of code inserted in a Markdown file that pulls in information from other files in your project.
 
 
 ## Include Figure Image Files in Your Publication

--- a/content/documentation/for-developers.md
+++ b/content/documentation/for-developers.md
@@ -340,7 +340,7 @@ Pages with `type: contents` can have class `list` (default), `brief`, `abstract`
 
 ### `q-class`
 
-Wrapping any Markdown text in this shortcode will wrap it in a `<div>` with the given class name in the HTML output. Used for styling.
+Used for styling. Wrapping any Markdown text in this shortcode will wrap it in a `<div>` with the given class name in the HTML output. 
 
 `{{</* q-class "" */>}}  {{</* /q-class */>}}`
 

--- a/content/documentation/fundamentals.md
+++ b/content/documentation/fundamentals.md
@@ -227,7 +227,7 @@ Footnotes can also include Markdown formatting, including lists and even multipl
 You can also use HTML tags in a Markdown file. This can be convenient for adding HTML elements that Markdown doesn’t support, or for applying special styling. For instance, by wrapping text with a `<span>` tag with a class in order to add custom styling. (See more about this in the [*Styles Customization*](/documentation/styles-customization/) chapter of this guide.) Note, however, that you can do the same by wrapping multiple paragraphs of Markdown in `<div>`, `<section>` or other block-level tags. For this, you need the `q-class` shortcode.
 
 {{< q-class "box tip" >}}
-- For the things Markdown can’t do, Quire includes number of useful shortcodes. You’ll read more about them in other chapters of this guide. A complete list is available in the [shortcode reference section](/documentation/for-developers/#shortcodes-api).
+- For the things Markdown can’t do, Quire includes number of useful {{< q-def "shortcodes" >}}. You’ll read more about them in other chapters of this guide. A complete list is available in the [shortcode reference section](/documentation/for-developers/#shortcodes-api).
 
 {{< / q-class >}}
 

--- a/content/documentation/page-content.md
+++ b/content/documentation/page-content.md
@@ -33,7 +33,7 @@ You can read all about Markdown syntax and how it is used in Quire in the [*Fund
 
 ## Use Shortcodes to Add Features
 
-Quire adds a number of specialty shortcodes which extend the functionality and possibilities of plain Markdown. While {{< q-def "Hugo" >}} has a number of built-in shortcodes, which can also work in Quire, Quire-specific shortcodes always start with a `q`.
+Quire adds a number of specialty {{< q-def "shortcodes" >}} which extend the functionality and possibilities of plain Markdown. While {{< q-def "Hugo" >}} has a number of built-in shortcodes, which can also work in Quire, Quire-specific shortcodes always start with a `q`.
 
 Shortcodes are always formatted with a combination of curly brackets and angle brackets with the name of the shortcode inside (`{{</* q-shortcode */>}}`) and often with some additional information in quotes. The example below inserts a figure in your document, matching a corresponding `id` with figure information stored in the publication’s `figures.yml` file.
 

--- a/data/glossary.yml
+++ b/data/glossary.yml
@@ -89,7 +89,7 @@ entries:
   - term: "Shortcode"
     alternates:
       - "shortcodes"
-    definition: "A shortcode is a simple snippet used inside a Markdown file, that Quire will render using a predefined template. Quire suports [a range of shortcodes](/documentation/for-developers/#shortcodes-api), and custom shortcodes can also be added."
+    definition: "A shortcode is a simple snippet of code inserted in a Markdown file that pulls in information from other files in your project. In Quire, shortcodes are used for styling, figure images, citations, bibliographies, and collaborators. Quire suports [a range of shortcodes](/documentation/for-developers/#shortcodes-api), and custom shortcodes can also be added."
   - term: "theme"
     alternates:
       - "themes"


### PR DESCRIPTION
Revised shortcode definition and added the q-def shortcode in various places. Where the q-def shortcode didn't work I added a short explanation. I didn't include "extend Markdown's capabilities" in glossary definition bc it's often used in the documentation text. 

Although shortcodes are fairly neatly summarized in the For Developers section, what do you think about a separate section dedicated to Shortcodes for non-developers. That would take away the need to keep redefining shortcodes every time they come up in a new section in the docs. 