### PR TITLE
Add: Info about PDF page numbering

### DIFF
--- a/content/documentation/contents-menu.md
+++ b/content/documentation/contents-menu.md
@@ -46,6 +46,18 @@ While the TOC is generated automatically by Quire based on the Markdown pages in
 Adding `toc: false` will only remove the page’s listing in the TOC. To entirely hide a page from Quire’s outputs use `online: false`, `pdf: false`, and `epub: false`.
 {{< /q-class >}}
 
+### Page Numbering in the PDF
+
+When you output your project as a PDF, page numbers will automatically be added to the pages and to the corresponding entries in the Table of Contents.
+
+The frontmatter pages of books are usually numbered in lowercase Roman numerals (i, ii, iii, iv, etc.). The Arabic numeral 1 is then assigned to the first page of true “content” for the book. Usually the first chapter, or an introduction. Quire handles things the same way.
+
+To assign a particular section to be page 1 of your project, add `class: page-one` to the Markdown file. This tag means that this section is page 1 (in Arabic numerals), and everything before it is frontmatter and so will be numbered in lowercase Roman.
+
+{{< q-class "box warning" >}}
+Only one page in your project can have the `class: page-one` tag.
+{{< /q-class >}}
+
 ## Sidebar Menu
 
 Like the TOC, the sidebar Menu is generated automatically by Quire based on the structure of the files in your `content` directory and the metadata of each page.


### PR DESCRIPTION
Thank you for contributing to the Quire Documentation & Website! Please complete the form below to submit your pull request for review.

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Edit, Add, Translate. Issue-# is only needed if this pull request addresses an exisiting issue.*

### Checklist 

Please put an X within the brackets that apply `[X]`.

- [x] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file.

- [x] I have made my changes in a new branch and not directly in the main branch

- [x] I am requesting feedback on a draft pull request


### Is this pull request related to an open issue? If so, what is the issue number?

Not an open issue, but stems from questions posted by a user in our forum (thanks @pancaketents!): https://github.com/thegetty/quire/discussions/182

### Please describe the goal of this pull request and the changes that were made.

Clarify the use of `class: page-one` in the PDF output.

### Additional Comments

@Erin-Cecele Feel free to edit or expand this as you'd like. And I left the tip in Page Types & Structure as is.