### PR TITLE
add warning re: cover image

### DIFF
--- a/content/docs-v1/pages.md
+++ b/content/docs-v1/pages.md
@@ -152,6 +152,12 @@ The way to create a publication cover page is similar to creating section landin
 
 Like in the case of sub-sections explained above, `index.md` files always inherit the URL of their parent directory. The `index.md` file used for your cover is in the root, or top-most, directory, and so the URL for it will be the base URL where you host the site.
 
+{{< q-class "box warning" >}}
+
+- Do not leave the `image` attribute blank or remove `image` completely from the page YAML, otherwise the build will break. 
+
+{{< /q-class >}}
+
 ## Hide/Show Pages
 
 By default, every page you create will be included in all formats of your publication (html, PDF/print, and e-book). This can be overridden by including an `outputs` attribute and excluding the undesired formats from the array (`epub`, `pdf`, `html`). For example, if you want your Copyright page to appear in the PDF and EPUB formats but not in the online version, you would only list `epub` and `pdf` as page YAML values.


### PR DESCRIPTION
Thank you for contributing to the Quire Documentation & Website! Please complete the form below to submit your pull request for review.

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Edit, Add, Translate. Issue-# is only needed if this pull request addresses an existing issue.*

### Checklist 

Please put an X within the brackets that apply `[X]`.

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file.

- [X] I have made my changes in a new branch and not directly in the main branch

- [ ] I am requesting feedback on a draft pull request


### Is this pull request related to an open issue? If so, what is the issue number?

Yes, this is related to https://github.com/thegetty/quire/issues/844. 

### Please describe the goal of this pull request and the changes that were made.

Add a warning telling people not to leave `image` blank on the cover or remove the `image` attribute from the page YAML of the cover.

### Additional Comments
