### PR TITLE
Add a recipe for using a video cover image

### DIFF
--- a/content/resources/recipes-video-cover.md
+++ b/content/resources/recipes-video-cover.md
@@ -12,7 +12,7 @@ You can have a video cover in Quire by making a few customizations to your proje
 
 {{< q-class "warn" >}}
 
-This will only work for the online/HTML version of your Quire project. This recipe does not offer fallbacks for the PDF or EPUB output.
+This will only work for the online/HTML version of your Quire project. This recipe does not offer fallbacks for the PDF or EPUB output. For those, you can create a static version as a JPG file. For EPUB, add the JPG to your `content/_assets/images` directory and list it under `epub.defaultCoverImage` in `content/_data/config.yaml`. For PDF, output your PDF file without a cover and manually add the static cover JPG directly as the first page.
 
 {{< /q-class >}}
 

--- a/content/resources/recipes-video-cover.md
+++ b/content/resources/recipes-video-cover.md
@@ -10,6 +10,12 @@ You can use an animated GIF or WEBP file to create an animated cover for your pr
 
 You can have a video cover in Quire by making a few customizations to your project. You'll want to use a short MP4 video that will work when played in a loop. The shorter the video clip, the smaller the file will be and the better it will load for your users.
 
+{{< q-class "warn" >}}
+
+This will only work for the online/HTML version of your Quire project. This recipe does not offer fallbacks for the PDF or EPUB output.
+
+{{< /q-class >}}
+
 Start by customizing the cover layout to display the video instead of a static image. In `_layouts/cover.liquid` replace:
 
 ```html
@@ -51,5 +57,7 @@ Finally, add your MP4 video file to `content/_assets/images` and reference it in
 layout: cover
 order: 1
 image: cover-video.mp4
+outputs:
+  - html
 ---
 ```

--- a/content/resources/recipes-video-cover.md
+++ b/content/resources/recipes-video-cover.md
@@ -1,0 +1,55 @@
+---
+label: RECIPE
+title: Display a Video Cover Image
+weight: 7356
+type: page
+online: false
+---
+
+You can use an animated GIF or WEBP file to create an animated cover for your project. Resolutions can often be an issue for these files though, as having a high-enough quality file to look good as a full-sized cover image, often results in a very large file size and poor load times for users. In these cases you may want to customize your project to instead use a short video file.
+
+You can have a video cover in Quire by making a few customizations to your project. You'll want to use a short MP4 video that will work when played in a loop. The shorter the video clip, the smaller the file will be and the better it will load for your users.
+
+Start by customizing the cover layout to display the video instead of a static image. In `_layouts/cover.liquid` replace:
+
+```html
+<div
+  class="quire-cover__overlay"
+  style="background-image: url('{{ imagePath }}');"
+  >
+  {% comment %} This ensures background image asset gets copied into epub package {% endcomment %}
+  <img class="visually-hidden" src="{{ imagePath }}" alt="" data-outputs-include="epub" />
+</div>
+```
+
+With: 
+
+```html
+<div class="quire-cover__overlay">
+  <video autoplay muted loop class="quire-cover__video">
+    <source src="{{ imagePath }}" type="video/mp4" />
+  </video>
+</div>
+```
+
+Next, add some CSS styles to ensure the video is sized properly. In `content/_assets/styles/custom.css` add:
+
+
+```css
+.quire-cover__video {
+  object-fit: cover;
+  min-height: calc(95vh - 3rem - 2px);
+  max-height: calc(95vh - 3rem - 2px);
+  width: 100vw;
+}
+```
+
+Finally, add your MP4 video file to `content/_assets/images` and reference it in `content/index.md` like you would any cover image:
+
+```yaml
+---
+layout: cover
+order: 1
+image: cover-video.mp4
+---
+```

--- a/content/resources/recipes.md
+++ b/content/resources/recipes.md
@@ -10,3 +10,4 @@ abstract: "Step-by-step guides on creating popular customizations to your projec
 - [Hide Table of Contents Grid in PDF with Custom Class](/resources/recipes-hide-grid/)
 - [Fix Long URLs in Pop-Up Citation Boxes with Custom CSS](/resources/recipes-long-urls)
 - [Add Markdown Functionality with Plugins](/resources/recipes-add-plugins)
+- [Display a Video Cover Image](/resources/recipes-video-cover)


### PR DESCRIPTION
Thank you for contributing to the Quire Documentation & Website! Please complete the form below to submit your pull request for review.

*For the Title of this pull request, please use the format "Type/Issue-#: Brief description." For Type, the options are Edit, Add, Translate. Issue-# is only needed if this pull request addresses an existing issue.*

### Checklist 

Please put an X within the brackets that apply `[X]`.

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file.

- [X] I have made my changes in a new branch and not directly in the main branch

- [ ] I am requesting feedback on a draft pull request


### Is this pull request related to an open issue? If so, what is the issue number?

No.

### Please describe the goal of this pull request and the changes that were made.

This describes the process of using a video cover image in place of an animated GIF or WEBP image, in order to have an animated cover.

### Additional Comments

We should later test and document the use of GIF and WEBP files for the cover in the PDF and EPUB output. I can't currently due to this issue: https://github.com/thegetty/quire/issues/1224.